### PR TITLE
Add iBridge version to module

### DIFF
--- a/ibridge_controller.php
+++ b/ibridge_controller.php
@@ -58,7 +58,7 @@ class Ibridge_controller extends Module_controller
             return;
         }
         
-        $sql = "SELECT model_name, model_identifier, build, ibridge_serial_number, boot_uuid, marketing_name
+        $sql = "SELECT model_name, model_identifier, build, ibridge_serial_number, ibridge_version, boot_uuid, marketing_name
                     FROM ibridge 
                     WHERE serial_number = '$serial_number'";
         

--- a/ibridge_model.php
+++ b/ibridge_model.php
@@ -15,6 +15,7 @@ class Ibridge_model extends \Model {
 		$this->rs['model_name'] = '';
 		$this->rs['ibridge_serial_number'] = '';
 		$this->rs['marketing_name'] = '';
+		$this->rs['ibridge_version'] '';
 		
 		if ($serial) {
 			$this->retrieve_record($serial);
@@ -72,7 +73,8 @@ class Ibridge_model extends \Model {
                 'model_identifier' => '',
                 'model_name' => '',
                 'ibridge_serial_number' => '',
-                'marketing_name' => ''
+                'marketing_name' => '',
+                'ibridge_version' => ''
             );
 
             foreach ($myList as $ibridge) {

--- a/ibridge_model.php
+++ b/ibridge_model.php
@@ -15,7 +15,7 @@ class Ibridge_model extends \Model {
 		$this->rs['model_name'] = '';
 		$this->rs['ibridge_serial_number'] = '';
 		$this->rs['marketing_name'] = '';
-		$this->rs['ibridge_version'] '';
+		$this->rs['ibridge_version'] = '';
 		
 		if ($serial) {
 			$this->retrieve_record($serial);

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,12 +1,13 @@
 {
+ "boot_uuid":"Boot UUID",
  "build":"OS Build",
- "ibridge_serial_number":"iBridge Serial Number",
- "marketing_name":"Version",
  "clienttab":"iBridge",
+ "ibridge_serial_number":"iBridge Serial Number",
+ "ibridge_version":"iBridge Version",
+ "marketing_name":"Version",
  "model_identifier":"Model ID",
  "model_name":"Model Name",
  "noibridge":"No iBridge Devices",
  "reporttitle":"iBridge Report",
- "widgettitle":"iBridge Versions",
- "boot_uuid":"Boot UUID"
+ "widgettitle":"iBridge Versions"
 }

--- a/migrations/2019_02_11_144341_ibridge_add_version_column.php
+++ b/migrations/2019_02_11_144341_ibridge_add_version_column.php
@@ -11,7 +11,7 @@ class iBridgeAddVersionColumn extends Migration
     {
         $capsule = new Capsule();
         $capsule::schema()->table($this->tableName, function (Blueprint $table) {
-            $table->string('ibridge_version')->default('');
+            $table->string('ibridge_version',128)->nullable();
             $table->index('ibridge_version');
         });
         

--- a/migrations/2019_02_11_144341_ibridge_add_version_column.php
+++ b/migrations/2019_02_11_144341_ibridge_add_version_column.php
@@ -1,0 +1,30 @@
+<?php
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+class iBridgeAddVersionColumn extends Migration
+{
+    private $tableName = 'ibridge';
+
+    public function up()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->table($this->tableName, function (Blueprint $table) {
+            $table->string('ibridge_version')->default('');
+            $table->index('ibridge_version');
+        });
+        
+        # Force reload local admin data
+        $capsule::unprepared("UPDATE hash SET hash = 'x' WHERE name = '$this->tableName'");
+
+    }
+    
+    public function down()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->table($this->tableName, function (Blueprint $table) {
+            $table->dropColumn('ibridge_version');
+        });
+    }
+}

--- a/views/ibridge_listing.php
+++ b/views/ibridge_listing.php
@@ -20,6 +20,7 @@ new Ibridge_model;
 			<th data-i18n="serial" data-colname='reportdata.serial_number'></th>
 			<th data-i18n="ibridge.model_name" data-colname='ibridge.model_name'></th>
 			<th data-i18n="ibridge.model_identifier" data-colname='ibridge.model_identifier'></th>
+			<th data-i18n="ibridge.ibridge_version" data-colname='ibridge.ibridge_version'></th>
 			<th data-i18n="ibridge.build" data-colname='ibridge.build'></th>
 			<th data-i18n="ibridge.ibridge_serial_number" data-colname='ibridge.ibridge_serial_number'></th>
 			<th data-i18n="ibridge.boot_uuid" data-colname='ibridge.boot_uuid'></th>


### PR DESCRIPTION
Even though the iBridge version data does exist in the client details Boot ROM data, I thought it would be good to have it added to the iBridge module for easier parsing.

![screenshot 2019-02-11 15 25 56](https://user-images.githubusercontent.com/1416288/52594591-8314a200-2e11-11e9-95bc-620bd0dfee7f.png)
![screenshot 2019-02-11 15 26 47](https://user-images.githubusercontent.com/1416288/52594594-860f9280-2e11-11e9-860c-c95a716a83bb.png)


-Eric